### PR TITLE
Fix Deprecation Warnings for RGBASM v0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ bin/%.sym bin/%.bin: obj/%.o
 
 obj/%.o: src/$${$$*_asm}
 	@mkdir -p ${@D}
-	rgbasm -p 0xFF -D $* -i src/ -o $@ $<
+	rgbasm -p 0xFF -D $* -I src/ -o $@ $<

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Disassemblies of the different Game Boy boot ROMs.
 
 ## Building
 
-Make sure to clone this repo with submodules, and to have [RGBDS](https://rgbds.gbdev.io) v0.5.0 or later installed.
+Make sure to clone this repo with submodules, and to have [RGBDS](https://rgbds.gbdev.io) v0.6.0 or later installed.
 
 Then simply run `make` in the repo's root directory to build the boot ROMs and check their validity, or `make all` to only do the former.

--- a/src/cgb.asm
+++ b/src/cgb.asm
@@ -11,16 +11,16 @@ INCLUDE "header.inc"
 ; 01: DMG/MGB mode (for execution of DMG/MGB exclusive cartridges)
 ; 10: PGB1 mode (a mode in which the CPU is stopped and the LCD is driven externally)
 ; 11: PGB2 mode (a mode in which the LCD is driven externally while the CPU is operating)
-rKEY0 equ $FF4C ; Side note: the register's name is consistent with rKEY1 at $FF4D
+DEF rKEY0 equ $FF4C ; Side note: the register's name is consistent with rKEY1 at $FF4D
 ; Internal/external rom bank register
 ; XXXXXXXr
 ; 0: monitor ROM, 1: cassette ROM
-rBANK equ $FF50
+DEF rBANK equ $FF50
 ; OBJ priority mode designation register
 ; XXXXXXXp
 ; 0: Lower OBJ-NO object priority
 ; 1: Smaller X coordinate object priority
-rOPRI equ $FF6C
+DEF rOPRI equ $FF6C
 
 ; KEY0 is known as the "CPU mode register" in Fig. 11 of this patent:
 ; https://patents.google.com/patent/US6322447B1/en?oq=US6322447bi
@@ -28,31 +28,31 @@ rOPRI equ $FF6C
 ; Credit to @mattcurrie for this finding!
 
 
-COLOR_MASK equ $1F ; Each color spans 5 bits
-COLOR_MAX equ $1F
-COLOR_SIZE equ 2 ; Colors are encoded as 2-byte little-endian BGR555
-COLORS_PER_PALETTE equ 4
-PALETTE_SIZE equ 8
+DEF COLOR_MASK equ $1F ; Each color spans 5 bits
+DEF COLOR_MAX equ $1F
+DEF COLOR_SIZE equ 2 ; Colors are encoded as 2-byte little-endian BGR555
+DEF COLORS_PER_PALETTE equ 4
+DEF PALETTE_SIZE equ 8
 
-TILE_SIZE equ 16
+DEF TILE_SIZE equ 16
 
-NB_OBJS equ 40 ; OAM contains 40 OBJs
-OBJ_SIZE equ 4 ; Each OAM OBJ is 4 bytes
-OAM_SIZE equ NB_OBJS * OBJ_SIZE
+DEF NB_OBJS equ 40 ; OAM contains 40 OBJs
+DEF OBJ_SIZE equ 4 ; Each OAM OBJ is 4 bytes
+DEF OAM_SIZE equ NB_OBJS * OBJ_SIZE
 
-WAVE_RAM_SIZE equ 16
+DEF WAVE_RAM_SIZE equ 16
 
 
 ; "GAME BOY" logo constants
-GB_LOGO_HEIGHT equ 3 ; The logo is 3 tile rows tall
-GB_LOGO_WIDTH equ 16 ; The logo is 12 tiles wide
-LOGO_BLOCK_WIDTH equ 3 ; Width in tiles of one color "block"
-NB_LOGO_PALETTES equs "((BootAnimationColors.end - BootAnimationColors) / COLOR_SIZE)"
-GB_LOGO_FIRST_TILE equs "LOW(vGameBoyLogoTiles / TILE_SIZE)"
+DEF GB_LOGO_HEIGHT equ 3 ; The logo is 3 tile rows tall
+DEF GB_LOGO_WIDTH equ 16 ; The logo is 12 tiles wide
+DEF LOGO_BLOCK_WIDTH equ 3 ; Width in tiles of one color "block"
+DEF NB_LOGO_PALETTES equs "((BootAnimationColors.end - BootAnimationColors) / COLOR_SIZE)"
+DEF GB_LOGO_FIRST_TILE equs "LOW(vGameBoyLogoTiles / TILE_SIZE)"
 
 ; Old "Nintendo" logo constants
-OLD_LOGO_HEIGHT equ 2
-OLD_LOGO_WIDTH equ 12
+DEF OLD_LOGO_HEIGHT equ 2
+DEF OLD_LOGO_WIDTH equ 12
 
 
 MACRO gdma_params

--- a/src/header.inc
+++ b/src/header.inc
@@ -1,14 +1,14 @@
-HeaderLogo equ $0104
-HeaderTitle equ $0134
-HeaderMenufacturer equ $013F
-HeaderCGBCompat equ $0143
-HeaderNewLicensee equ $0144
-HeaderSGBFlag equ $0146
-HeaderCartType equ $0147
-HeaderROMSize equ $0148
-HeaderRAMSize equ $0149
-HeaderRegionCode equ $014A
-HeaderOldLicensee equ $014B
-HeaderROMVersion equ $014C
-HeaderChecksum equ $014D
-HeaderGlobalChecksum equ $014E
+DEF HeaderLogo equ $0104
+DEF HeaderTitle equ $0134
+DEF HeaderMenufacturer equ $013F
+DEF HeaderCGBCompat equ $0143
+DEF HeaderNewLicensee equ $0144
+DEF HeaderSGBFlag equ $0146
+DEF HeaderCartType equ $0147
+DEF HeaderROMSize equ $0148
+DEF HeaderRAMSize equ $0149
+DEF HeaderRegionCode equ $014A
+DEF HeaderOldLicensee equ $014B
+DEF HeaderROMVersion equ $014C
+DEF HeaderChecksum equ $014D
+DEF HeaderGlobalChecksum equ $014E

--- a/src/stadium2.asm
+++ b/src/stadium2.asm
@@ -4,31 +4,31 @@
 INCLUDE "hardware.inc/hardware.inc"
 
 
-COLOR_MASK equ $1F ; Each color spans 5 bits
-COLOR_MAX equ $1F
-COLOR_SIZE equ 2 ; Colors are encoded as 2-byte little-endian BGR555
-COLORS_PER_PALETTE equ 4
-PALETTE_SIZE equ COLOR_SIZE * COLORS_PER_PALETTE
+DEF COLOR_MASK equ $1F ; Each color spans 5 bits
+DEF COLOR_MAX equ $1F
+DEF COLOR_SIZE equ 2 ; Colors are encoded as 2-byte little-endian BGR555
+DEF COLORS_PER_PALETTE equ 4
+DEF PALETTE_SIZE equ COLOR_SIZE * COLORS_PER_PALETTE
 
-TILE_SIZE equ 16
+DEF TILE_SIZE equ 16
 
-NB_OBJS equ 40 ; OAM contains 40 OBJs
-OBJ_SIZE equ 4 ; Each OAM OBJ is 4 bytes
-OAM_SIZE equ NB_OBJS * OBJ_SIZE
+DEF NB_OBJS equ 40 ; OAM contains 40 OBJs
+DEF OBJ_SIZE equ 4 ; Each OAM OBJ is 4 bytes
+DEF OAM_SIZE equ NB_OBJS * OBJ_SIZE
 
-WAVE_RAM_SIZE equ 16
+DEF WAVE_RAM_SIZE equ 16
 
 
 ; "GAME BOY" logo constants
-GB_LOGO_HEIGHT equ 3 ; The logo is 3 tile rows tall
-GB_LOGO_WIDTH equ 16 ; The logo is 12 tiles wide
-LOGO_BLOCK_WIDTH equ 3 ; Width in tiles of one color "block"
-NB_LOGO_PALETTES equs "((BootAnimationColorsEnd - BootAnimationColors) / COLOR_SIZE)"
-GB_LOGO_FIRST_TILE equs "LOW(vGameBoyLogoTiles / TILE_SIZE)"
+DEF GB_LOGO_HEIGHT equ 3 ; The logo is 3 tile rows tall
+DEF GB_LOGO_WIDTH equ 16 ; The logo is 12 tiles wide
+DEF LOGO_BLOCK_WIDTH equ 3 ; Width in tiles of one color "block"
+DEF NB_LOGO_PALETTES equs "((BootAnimationColorsEnd - BootAnimationColors) / COLOR_SIZE)"
+DEF GB_LOGO_FIRST_TILE equs "LOW(vGameBoyLogoTiles / TILE_SIZE)"
 
 ; Old "Nintendo" logo constants
-OLD_LOGO_HEIGHT equ 2
-OLD_LOGO_WIDTH equ 12
+DEF OLD_LOGO_HEIGHT equ 2
+DEF OLD_LOGO_WIDTH equ 12
 
 
 MACRO gdma_params
@@ -45,7 +45,7 @@ MACRO rgb
 ENDM
 
 
-rBANK equ $FF50 ; Boot ROM lockout reg
+DEF rBANK equ $FF50 ; Boot ROM lockout reg
 
 
 SECTION "First section", ROM0[$0000]


### PR DESCRIPTION
Removes the warnings when running `make` using `rgbasm v0.7.0-4-g37415101`.
I tested the output bootroms using [Emulicious](https://emulicious.net/) and detected no issues.

**Changes**
- Defining symbols without using DEF ([changed in v0.7.0](https://github.com/gbdev/rgbds/releases/tag/v0.7.0))
- Please prefer `rgbasm -I` over `rgbasm -i`; `-i` will be phased out in a future release ([changed in v.0.6.0](https://github.com/gbdev/rgbds/releases/tag/v0.6.0))

**Warning Logs**

Sample of `-i` Warnings:
```
rgbasm -p 0xFF -D dmg0 -i src/ -o obj/dmg0.o src/dmg.asm
warning: at top level: [-Wobsolete]
    `-i` is deprecated; use `-I`
```

Sample of Symbol Warnings:
```
warning: src/dmg.asm(2) -> src/header.inc(1): [-Wobsolete]
    `HeaderLogo EQU` is deprecated; use `DEF HeaderLogo EQU`
warning: src/dmg.asm(2) -> src/header.inc(2): [-Wobsolete]
    `HeaderTitle EQU` is deprecated; use `DEF HeaderTitle EQU`
...
```

<details>
  <summary>Full EQU & EQUS warnings log (all resolved)</summary>

```
warning: src/dmg.asm(2) -> src/header.inc(1): [-Wobsolete]
    `HeaderLogo EQU` is deprecated; use `DEF HeaderLogo EQU`
warning: src/dmg.asm(2) -> src/header.inc(2): [-Wobsolete]
    `HeaderTitle EQU` is deprecated; use `DEF HeaderTitle EQU`
warning: src/dmg.asm(2) -> src/header.inc(3): [-Wobsolete]
    `HeaderMenufacturer EQU` is deprecated; use `DEF HeaderMenufacturer EQU`
warning: src/dmg.asm(2) -> src/header.inc(4): [-Wobsolete]
    `HeaderCGBCompat EQU` is deprecated; use `DEF HeaderCGBCompat EQU`
warning: src/dmg.asm(2) -> src/header.inc(5): [-Wobsolete]
    `HeaderNewLicensee EQU` is deprecated; use `DEF HeaderNewLicensee EQU`
warning: src/dmg.asm(2) -> src/header.inc(6): [-Wobsolete]
    `HeaderSGBFlag EQU` is deprecated; use `DEF HeaderSGBFlag EQU`
warning: src/dmg.asm(2) -> src/header.inc(7): [-Wobsolete]
    `HeaderCartType EQU` is deprecated; use `DEF HeaderCartType EQU`
warning: src/dmg.asm(2) -> src/header.inc(8): [-Wobsolete]
    `HeaderROMSize EQU` is deprecated; use `DEF HeaderROMSize EQU`
warning: src/dmg.asm(2) -> src/header.inc(9): [-Wobsolete]
    `HeaderRAMSize EQU` is deprecated; use `DEF HeaderRAMSize EQU`
warning: src/dmg.asm(2) -> src/header.inc(10): [-Wobsolete]
    `HeaderRegionCode EQU` is deprecated; use `DEF HeaderRegionCode EQU`
warning: src/dmg.asm(2) -> src/header.inc(11): [-Wobsolete]
    `HeaderOldLicensee EQU` is deprecated; use `DEF HeaderOldLicensee EQU`
warning: src/dmg.asm(2) -> src/header.inc(12): [-Wobsolete]
    `HeaderROMVersion EQU` is deprecated; use `DEF HeaderROMVersion EQU`
warning: src/dmg.asm(2) -> src/header.inc(13): [-Wobsolete]
    `HeaderChecksum EQU` is deprecated; use `DEF HeaderChecksum EQU`
warning: src/dmg.asm(2) -> src/header.inc(14): [-Wobsolete]
    `HeaderGlobalChecksum EQU` is deprecated; use `DEF HeaderGlobalChecksum EQU`

warning: src/cgb.asm(14): [-Wobsolete]
    `rKEY0 EQU` is deprecated; use `DEF rKEY0 EQU`
warning: src/cgb.asm(18): [-Wobsolete]
    `rBANK EQU` is deprecated; use `DEF rBANK EQU`
warning: src/cgb.asm(23): [-Wobsolete]
    `rOPRI EQU` is deprecated; use `DEF rOPRI EQU`
warning: src/cgb.asm(31): [-Wobsolete]
    `COLOR_MASK EQU` is deprecated; use `DEF COLOR_MASK EQU`
warning: src/cgb.asm(32): [-Wobsolete]
    `COLOR_MAX EQU` is deprecated; use `DEF COLOR_MAX EQU`
warning: src/cgb.asm(33): [-Wobsolete]
    `COLOR_SIZE EQU` is deprecated; use `DEF COLOR_SIZE EQU`
warning: src/cgb.asm(34): [-Wobsolete]
    `COLORS_PER_PALETTE EQU` is deprecated; use `DEF COLORS_PER_PALETTE EQU`
warning: src/cgb.asm(35): [-Wobsolete]
    `PALETTE_SIZE EQU` is deprecated; use `DEF PALETTE_SIZE EQU`
warning: src/cgb.asm(37): [-Wobsolete]
    `TILE_SIZE EQU` is deprecated; use `DEF TILE_SIZE EQU`
warning: src/cgb.asm(39): [-Wobsolete]
    `NB_OBJS EQU` is deprecated; use `DEF NB_OBJS EQU`
warning: src/cgb.asm(40): [-Wobsolete]
    `OBJ_SIZE EQU` is deprecated; use `DEF OBJ_SIZE EQU`
warning: src/cgb.asm(41): [-Wobsolete]
    `OAM_SIZE EQU` is deprecated; use `DEF OAM_SIZE EQU`
warning: src/cgb.asm(43): [-Wobsolete]
    `WAVE_RAM_SIZE EQU` is deprecated; use `DEF WAVE_RAM_SIZE EQU`
warning: src/cgb.asm(47): [-Wobsolete]
    `GB_LOGO_HEIGHT EQU` is deprecated; use `DEF GB_LOGO_HEIGHT EQU`
warning: src/cgb.asm(48): [-Wobsolete]
    `GB_LOGO_WIDTH EQU` is deprecated; use `DEF GB_LOGO_WIDTH EQU`
warning: src/cgb.asm(49): [-Wobsolete]
    `LOGO_BLOCK_WIDTH EQU` is deprecated; use `DEF LOGO_BLOCK_WIDTH EQU`
warning: src/cgb.asm(50): [-Wobsolete]
    `NB_LOGO_PALETTES EQUS` is deprecated; use `DEF NB_LOGO_PALETTES EQUS`
warning: src/cgb.asm(51): [-Wobsolete]
    `GB_LOGO_FIRST_TILE EQUS` is deprecated; use `DEF GB_LOGO_FIRST_TILE EQUS`
warning: src/cgb.asm(54): [-Wobsolete]
    `OLD_LOGO_HEIGHT EQU` is deprecated; use `DEF OLD_LOGO_HEIGHT EQU`
warning: src/cgb.asm(55): [-Wobsolete]
    `OLD_LOGO_WIDTH EQU` is deprecated; use `DEF OLD_LOGO_WIDTH EQU`

warning: src/stadium2.asm(7): [-Wobsolete]
    `COLOR_MASK EQU` is deprecated; use `DEF COLOR_MASK EQU`
warning: src/stadium2.asm(8): [-Wobsolete]
    `COLOR_MAX EQU` is deprecated; use `DEF COLOR_MAX EQU`
warning: src/stadium2.asm(9): [-Wobsolete]
    `COLOR_SIZE EQU` is deprecated; use `DEF COLOR_SIZE EQU`
warning: src/stadium2.asm(10): [-Wobsolete]
    `COLORS_PER_PALETTE EQU` is deprecated; use `DEF COLORS_PER_PALETTE EQU`
warning: src/stadium2.asm(11): [-Wobsolete]
    `PALETTE_SIZE EQU` is deprecated; use `DEF PALETTE_SIZE EQU`
warning: src/stadium2.asm(13): [-Wobsolete]
    `TILE_SIZE EQU` is deprecated; use `DEF TILE_SIZE EQU`
warning: src/stadium2.asm(15): [-Wobsolete]
    `NB_OBJS EQU` is deprecated; use `DEF NB_OBJS EQU`
warning: src/stadium2.asm(16): [-Wobsolete]
    `OBJ_SIZE EQU` is deprecated; use `DEF OBJ_SIZE EQU`
warning: src/stadium2.asm(17): [-Wobsolete]
    `OAM_SIZE EQU` is deprecated; use `DEF OAM_SIZE EQU`
warning: src/stadium2.asm(19): [-Wobsolete]
    `WAVE_RAM_SIZE EQU` is deprecated; use `DEF WAVE_RAM_SIZE EQU`
warning: src/stadium2.asm(23): [-Wobsolete]
    `GB_LOGO_HEIGHT EQU` is deprecated; use `DEF GB_LOGO_HEIGHT EQU`
warning: src/stadium2.asm(24): [-Wobsolete]
    `GB_LOGO_WIDTH EQU` is deprecated; use `DEF GB_LOGO_WIDTH EQU`
warning: src/stadium2.asm(25): [-Wobsolete]
    `LOGO_BLOCK_WIDTH EQU` is deprecated; use `DEF LOGO_BLOCK_WIDTH EQU`
warning: src/stadium2.asm(26): [-Wobsolete]
    `NB_LOGO_PALETTES EQUS` is deprecated; use `DEF NB_LOGO_PALETTES EQUS`
warning: src/stadium2.asm(27): [-Wobsolete]
    `GB_LOGO_FIRST_TILE EQUS` is deprecated; use `DEF GB_LOGO_FIRST_TILE EQUS`
warning: src/stadium2.asm(30): [-Wobsolete]
    `OLD_LOGO_HEIGHT EQU` is deprecated; use `DEF OLD_LOGO_HEIGHT EQU`
warning: src/stadium2.asm(31): [-Wobsolete]
    `OLD_LOGO_WIDTH EQU` is deprecated; use `DEF OLD_LOGO_WIDTH EQU`
warning: src/stadium2.asm(48): [-Wobsolete]
    `rBANK EQU` is deprecated; use `DEF rBANK EQU`
```
</details>

**Questions**
- Should the [README.md](https://github.com/ISSOtm/gb-bootroms/blob/508d9c1087617b63d54b5bcf2c700ae692c540c2/README.md?plain=1#L7) be updated to say `RGBDS v0.7.0 or later installed`?