### PR TITLE
Delete rOPRI redefinition

### DIFF
--- a/src/cgb.asm
+++ b/src/cgb.asm
@@ -16,11 +16,6 @@ DEF rKEY0 equ $FF4C ; Side note: the register's name is consistent with rKEY1 at
 ; XXXXXXXr
 ; 0: monitor ROM, 1: cassette ROM
 DEF rBANK equ $FF50
-; OBJ priority mode designation register
-; XXXXXXXp
-; 0: Lower OBJ-NO object priority
-; 1: Smaller X coordinate object priority
-DEF rOPRI equ $FF6C
 
 ; KEY0 is known as the "CPU mode register" in Fig. 11 of this patent:
 ; https://patents.google.com/patent/US6322447B1/en?oq=US6322447bi


### PR DESCRIPTION
Compiling `cgb.asm` with `rgbasm` version 0.8.0 gives the following error:

```sh
error: src/cgb.asm(23):
    'rOPRI' already defined at src/cgb.asm(1) -> src/hardware.inc/hardware.inc(816)
error: Assembly aborted (1 error)!
make: *** [Makefile:55: obj/cgb0.o] Error 1
```

which is easily fixed by commenting out the redefinition of rOPRI.