### PR TITLE
Make the build work on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifeq ($(UNAME_S), Darwin)
 endif
 
 compare: sha256sums.txt all
-	$(SHASUM) -c $<
+	${SHASUM} -c $<
 .PHONY: compare
 
 BINS := $(patsubst %,bin/%.bin,${MODELS})

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,14 @@ agb_size  := 2304
 stadium2_asm  := stadium2.asm
 stadium2_size := 1008
 
+UNAME_S := $(shell uname -s)
+SHASUM := sha256sum
+ifeq ($(UNAME_S), Darwin)
+	SHASUM = shasum -a 256
+endif
 
 compare: sha256sums.txt all
-	sha256sum -c $<
+	$(SHASUM) -c $<
 .PHONY: compare
 
 BINS := $(patsubst %,bin/%.bin,${MODELS})


### PR DESCRIPTION
The `sha256sum` binary doesn't exist on macOS, this PR factorizes the command to run a sha256 checksum.